### PR TITLE
Add cors from bloodlines.handlers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM golang
 
-ENV PORT "8080"
 ADD ./covenant /go/bin/covenant
 ADD ./config.json /go/bin/config.json
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,2 @@
+docker build -t ghmeier/covenant ./
+docker push ghmeier/covenant

--- a/router/router.go
+++ b/router/router.go
@@ -49,6 +49,7 @@ func New(config *config.Root) (*Subscription, error) {
 
 func InitRouter(s *Subscription) {
 	s.router = gin.Default()
+	s.router.Use(h.GetCors())
 
 	subscription := s.router.Group("/api/subscription")
 	{


### PR DESCRIPTION
This adds a function to handle cross origin requests so we don't have to worry about it on the front end.